### PR TITLE
Use 'address' property of SocketAddress object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export const ip = (config: {
     return app.derive(({ request }) => {
         const clientIP = getIP(request.headers, config.checkHeaders)
         return {
-            ip: clientIP || app.server!.requestIP(request)
+            ip: clientIP || app.server!.requestIP(request)!.address
         }
     })
 }


### PR DESCRIPTION
Bun's `server.requestIP` returns an instance of SocketAddress. This creates inconsistency between types `string` (returned when getting IP by headers) and `SocketAddress` (returned by `requestIP` method.) 

This PR modifies the returned object of the Elysia derivation so that it uses the address property to return a string of the connecting user's IP address, consistent with the header-based check.