### PR TITLE
Do not use server.requestIP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,16 +38,8 @@ export const ip = (config: {
 } = {}) => (app: Elysia) => {
     return app.derive({ as: 'global' }, ({ request }) => {
         // @ts-ignore
-        if (globalThis.Bun) {
-            if (!app.server) throw new Error(`Elysia server is not initialized. Make sure to call Elyisa.listen()`)
-            return {
-                ip: app.server.requestIP(request)
-            }
-        }
-        // @ts-ignore
-        const clientIP = getIP(request.headers, config.checkHeaders)
         return {
-            ip: clientIP
+            ip: getIP(request.headers, config.checkHeaders)
         }
     })
 }


### PR DESCRIPTION
If you use `requestIP`, It will ignore the options(`checkHeaders`) and just return the IP from the socket.
This will make the middleware return the ::ffff:127.0.0.1 when using reverse proxy.