### PR TITLE
Refactor: convert anonymous functions to named functions for OpenTelemetry

### DIFF
--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -14,7 +14,7 @@ export const plugin = function ipPlugin(userOptions?: Partial<Options>) {
     return app.use(
       new Elysia({
         name: "elysia-ip",
-      }).derive({ as: "global" }, function serverIP({ request }): { ip: string } {
+      }).derive({ as: "global" }, function ip({ request }): { ip: string } {
         serverIP: {
           if (!options.headersOnly && globalThis.Bun) {
             const server = options.injectServer(app);

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -14,7 +14,7 @@ export const plugin = function ipPlugin(userOptions?: Partial<Options>) {
     return app.use(
       new Elysia({
         name: "elysia-ip",
-      }).derive({ as: "global" }, function serverIP({ request }): { ip: string } => {
+      }).derive({ as: "global" }, function serverIP({ request }): { ip: string } {
         serverIP: {
           if (!options.headersOnly && globalThis.Bun) {
             const server = options.injectServer(app);

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -4,45 +4,47 @@ import { defaultOptions } from "../constants";
 import { debug } from "./debug";
 import type { Options } from "../types";
 
-export const plugin = (userOptions?: Partial<Options>) => (app: Elysia) => {
-  const options: Options = {
-    ...defaultOptions,
-    ...userOptions,
-  };
-
-  return app.use(
-    new Elysia({
-      name: "elysia-ip",
-    }).derive({ as: "global" }, ({ request }): { ip: string } => {
-      serverIP: {
-        if (!options.headersOnly && globalThis.Bun) {
-          const server = options.injectServer(app);
-          if (!server) {
-            debug(
-              "plugin: Elysia server is not initialized. Make sure to call Elyisa.listen()",
-            );
-            debug("plugin: use injectServer to inject Server instance");
-            break serverIP;
+export const plugin = function ipPlugin(userOptions?: Partial<Options>) {
+  return function registerIpPlugin(app: Elysia) {
+    const options: Options = {
+      ...defaultOptions,
+      ...userOptions,
+    };
+  
+    return app.use(
+      new Elysia({
+        name: "elysia-ip",
+      }).derive({ as: "global" }, function serverIP({ request }): { ip: string } => {
+        serverIP: {
+          if (!options.headersOnly && globalThis.Bun) {
+            const server = options.injectServer(app);
+            if (!server) {
+              debug(
+                "plugin: Elysia server is not initialized. Make sure to call Elyisa.listen()",
+              );
+              debug("plugin: use injectServer to inject Server instance");
+              break serverIP;
+            }
+  
+            if (!server.requestIP) {
+              debug("plugin: server.requestIP is null");
+              debug("plugin: Please check server instace");
+              break serverIP;
+            }
+  
+            const socketAddress = server.requestIP(request);
+            debug(`plugin: socketAddress ${JSON.stringify(socketAddress)}`);
+            if (!socketAddress) {
+              debug("plugin: ip from server.requestIP return `null`");
+              break serverIP;
+            }
+            return { ip: socketAddress.address };
           }
-
-          if (!server.requestIP) {
-            debug("plugin: server.requestIP is null");
-            debug("plugin: Please check server instace");
-            break serverIP;
-          }
-
-          const socketAddress = server.requestIP(request);
-          debug(`plugin: socketAddress ${JSON.stringify(socketAddress)}`);
-          if (!socketAddress) {
-            debug("plugin: ip from server.requestIP return `null`");
-            break serverIP;
-          }
-          return { ip: socketAddress.address };
         }
-      }
-      return {
-        ip: getIP(request.headers, options.checkHeaders) || "",
-      };
-    }),
-  );
+        return {
+          ip: getIP(request.headers, options.checkHeaders) || "",
+        };
+      }),
+    );
+  };
 };


### PR DESCRIPTION
Convert anonymous arrow functions to named functions across plugins for enhanced OpenTelemetry observability and debugging.

Changes:
- Server timing plugin: Add meaningful names to trace handlers and lifecycle callbacks
- Rate limiting plugin: Name factory and registration functions  
- IP plugin: Name derivation handlers and plugin functions

Benefits:
- Better span names in OpenTelemetry traces
- Improved error stack traces with function names
- Enhanced debugging and profiling visibility
- Clearer APM monitoring and performance analysis

This improves production observability by making function calls identifiable in monitoring tools instead of showing generic "anonymous function" labels.