### PR TITLE
fix: fetch ip correctly in nested plugin usage

### DIFF
--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -14,10 +14,10 @@ export const plugin = function ipPlugin(userOptions?: Partial<Options>) {
     return app.use(
       new Elysia({
         name: "elysia-ip",
-      }).derive({ as: "global" }, function ip({ request }): { ip: string } {
+      }).derive({ as: "global" }, function ip({ server: ctxServer, request }): { ip: string } {
         serverIP: {
           if (!options.headersOnly && globalThis.Bun) {
-            const server = options.injectServer(app);
+            const server = options.injectServer(app) ?? ctxServer;
             if (!server) {
               debug(
                 "plugin: Elysia server is not initialized. Make sure to call Elyisa.listen()",


### PR DESCRIPTION
Fixes gaurishhs#37

This fixes the issue where `ip` is an empty string when the plugin is used inside another plugin.

This issue may not be a problem when the plugin is applied directly to the main server, but I think it might cause issues when used within another plugin.